### PR TITLE
Cross-compilation 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ else()
     message(STATUS "Doxygen not found. You won't be able to build documentation.")
 endif()
 
-if(UNIX)
+if(UNIX AND NOT ANDROID)
     set(PHYSFS_TARBALL "${CMAKE_CURRENT_SOURCE_DIR}/../physfs-${PHYSFS_VERSION}.tar.bz2")
     add_custom_target(
         dist


### PR DESCRIPTION
Both SDL and physfs define the same uninstall target. This upsets the build system somewhat. Since we don't care about installation/uninstallation on Android anyway, we may safely not add this target.

This is required for Android port of OpenApoc.